### PR TITLE
pyocd: bump to 0.35.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ oscrypto<1.4
 pycryptodome>=3.9.3,<3.18
 pylink-square>=0.8.2,<0.15
 pyocd-pemicro>=1.1.5,<1.2
-pyocd>=0.33.0,<0.35
+pyocd>=0.35.0,<0.36
 pypemicro>=0.1.11,<0.2
 pyserial>=3.1,<3.6
 ruamel.yaml>=0.17,<0.18

--- a/spsdk/debuggers/debug_probe_pyocd.py
+++ b/spsdk/debuggers/debug_probe_pyocd.py
@@ -114,7 +114,7 @@ class DebugProbePyOCD(DebugProbe):
             self.probe.open()
             self.probe.connect(pyocd.probe.debug_probe.DebugProbe.Protocol.SWD)
             # Do reset sequence to switch to used protocol
-            connector = DPConnector(self.probe)
+            connector = DPConnector(self.probe, self.probe.session.board.target.dp)
             connector.connect()
             logger.debug(connector._idr)
             # Power Up the system and debug and clear sticky errors


### PR DESCRIPTION
Update to pyocd v0.35.0
https://github.com/pyocd/pyOCD/releases/tag/v0.35.0

The debug sequence handling introduced in v0.35.0 requires a one-line change in `debug_probe_pyocd.py`