### PR TITLE
Add support for multiple SEC_UNLOCK sections in BD file

### DIFF
--- a/spsdk/image/hab/segments.py
+++ b/spsdk/image/hab/segments.py
@@ -420,7 +420,8 @@ class CsfHabSegment(HabSegmentBase):
             command_class = COMMANDS_MAPPING.get(SecCommand.from_tag(cmd_config.index))
             if not command_class:
                 raise SPSDKValueError(f"Command with index does not exist {cmd_config.index}")
-            commands.append(command_class.load_from_config(config, search_paths=search_paths))
+            cmd_objs = command_class.load_from_config(config, search_paths=search_paths)
+            commands.extend(cmd_objs if isinstance(cmd_objs, list) else [cmd_objs])
         segment = SegCSF(enabled=True, version=header.version)
         for command in commands:
             segment.append_command(command.cmd)


### PR DESCRIPTION
**Summary**
Enable the ability to unlock multiple features from different engines using the boot descriptor (BD) file with multiple SEC_UNLOCK sections

**Background**
Currently, there is no way to unlock features from different engines simultaneously using the BD file, as only the first SEC_UNLOCK section is processed.

**Solution**
To unlock several features from different engines, multiple SEC_UNLOCK sections can be used in the BD file:
```
'section (SEC_UNLOCK; 
    Unlock_Engine = "SNVS",
    Unlock_features = "ZMK WRITE")
{
}

section (SEC_UNLOCK; 
    Unlock_Engine = "OCOTP", 
    Unlock_features = "SRK REVOKE")
{
}
```
Tested with i.MXRT1061 processor.