### PR TITLE
Fix --override-config parsing

### DIFF
--- a/spsdk/apps/utils/common_cli_options.py
+++ b/spsdk/apps/utils/common_cli_options.py
@@ -579,7 +579,7 @@ def spsdk_config_option(
             cfg.search_paths = [cfg_dir]
             cfg.config_dir = cfg_dir
             for oc in override_config:
-                pair = oc.split("=")
+                pair = oc.split("=", 1)
                 cfg[pair[0]] = pair[1]
 
             if klass:


### PR DESCRIPTION
Config values can contain an equals sign (e.g. Signer values), so only split on the first =.