### PR TITLE
fix(bimg): restore binary-file fallback for segment load_config

### DIFF
--- a/spsdk/utils/misc.py
+++ b/spsdk/utils/misc.py
@@ -1103,6 +1103,13 @@ def load_configuration(path: str, search_paths: Optional[list[str]] = None) -> d
 
     if not config_data:
         error_to_show = _determine_primary_parsing_error(config, json_error, yaml_error)
+        if json_error and yaml_error and "\x00" in config:
+            # Both parsers failed and content contains null bytes — the path points to a
+            # binary file, not a text config. Raise SPSDKNotTextFileError so callers such
+            # as SegmentFcb/SegmentXmcd load_config() can trigger their binary fallback.
+            raise SPSDKNotTextFileError(
+                f"Configuration file is not a text file (binary content detected): {path}"
+            ) from error_to_show
         raise SPSDKParsingError(
             f"Can't parse configuration file: {path}: {error_to_show if error_to_show else 'Unknown error'}"
         ) from error_to_show


### PR DESCRIPTION
## Problem

Since SPSDK 3.8.0 (commit `c997bedd`), passing a pre-built binary file as a segment path in a bootable-image config — e.g.:

```yaml
fcb: path/to/fcb.bin
```

fails with:

```
SPSDKParsingError: Can't parse configuration file: path/to/fcb.bin:
  unacceptable character #x0000: special characters are not allowed
```

This affects all six segment types that have a binary-fallback path in their `load_config()`: **FCB, XMCD, MBI, HAB, AHAB, SB21**.

## Root cause

Two simultaneous narrowing changes in 3.8.0 together made the binary fallback dead code:

| Location | Before 3.8.0 | After 3.8.0 |
|---|---|---|
| `segments.py` `SegmentFcb.load_config()` | `except SPSDKError:` (broad — catches `SPSDKParsingError` as subclass) | `except SPSDKNotTextFileError:` (sibling class — never matched) |
| `misc.py` `load_configuration()` | YAML error → `SPSDKError` | YAML error → `SPSDKParsingError` |

Binary files (FCB, XMCD etc.) that contain null bytes (`\x00`) are valid UTF-8, so `load_text()` reads them without raising `UnicodeDecodeError`. The YAML parser then rejects the null bytes with `yaml.YAMLError`, which `load_configuration()` converts to `SPSDKParsingError`. Since `SPSDKParsingError` and `SPSDKNotTextFileError` are **sibling** subclasses of `SPSDKError`, the `except SPSDKNotTextFileError` in the segment loaders is never matched, and the binary fallback never runs.

## Fix

In `load_configuration()`, when both JSON and YAML parsers fail **and** the content contains null bytes, raise `SPSDKNotTextFileError` instead of `SPSDKParsingError`. This is a reliable heuristic for NXP binary formats — FCB, XMCD, MBI, HAB, AHAB and SB21 binaries always contain zero-padded or reserved fields — and it precisely restores the pre-3.8.0 behaviour without touching any of the six affected segment classes.

```python
# misc.py load_configuration() — added 3 lines
if json_error and yaml_error and "\x00" in config:
    raise SPSDKNotTextFileError(
        f"Configuration file is not a text file (binary content detected): {path}"
    ) from error_to_show
```

The fix is **DRY** (one change covers all six segment types) and **safe** (malformed text YAML configs still raise `SPSDKParsingError` with the original message — they do not contain null bytes).

## Testing

The existing integration test `test_nxpimage_bimg_merge` for `mimxrt595s/flexspi_nor/xip_crc` uses `fcb: fcb.bin` with a real FCB binary and exercises this exact path.